### PR TITLE
Allow resolving sensitive info from environment

### DIFF
--- a/src/main/resources/wowchat.conf
+++ b/src/main/resources/wowchat.conf
@@ -1,6 +1,7 @@
 # Global Discord Configurations
 discord {
   token=<paste bot token here>
+  token=${?DISC_TOKEN}
 
   enable_dot_commands=1
 
@@ -33,8 +34,11 @@ wow {
   realmlist=167.114.128.42
   realm=The Construct
   account=<discord bot account>
+  account=${?WOW_ACC}
   password=<discord bot password>
+  password=${?WOW_PWD}
   character=<in game character>
+  character=${?WOW_CHR}
 
 # Other example configurations
 

--- a/src/main/scala/wowchat/common/Config.scala
+++ b/src/main/scala/wowchat/common/Config.scala
@@ -30,7 +30,7 @@ object WowChatConfig extends GamePackets {
   def apply(confFile: String): WowChatConfig = {
     val file = new File(confFile)
     val config = if (file.exists) {
-      ConfigFactory.parseFile(file)
+      ConfigFactory.parseFile(file).resolve()
     } else {
       ConfigFactory.load(confFile)
     }


### PR DESCRIPTION
Let config fallback to resolving sensitive info from environment if available, update template wowchat.conf with example env variable names.

Makes it possible to host the bot online (for example heroku) keeping sensitive information private.