### PR TITLE
Discord now has markdown support for embedding links into text

### DIFF
--- a/src/main/scala/wowchat/discord/MessageResolver.scala
+++ b/src/main/scala/wowchat/discord/MessageResolver.scala
@@ -35,14 +35,14 @@ class MessageResolver(jda: JDA) {
     linkRegexes.foldLeft(message) {
       case (result, (classicDbKey, regex)) =>
         regex.replaceAllIn(result, m => {
-          s"[${m.group(2)}] ($linkSite?$classicDbKey=${m.group(1)}) "
+          s"[[${m.group(2)}]($linkSite?$classicDbKey=${m.group(1)})] "
         })
     }
   }
 
   def resolveAchievementId(achievementId: Int): String = {
     val name = GameResources.ACHIEVEMENT.getOrElse(achievementId, achievementId)
-    s"[$name] ($linkSite?achievement=$achievementId) "
+    s"[[$name]($linkSite?achievement=$achievementId)] "
   }
 
   def stripColorCoding(message: String): String = {


### PR DESCRIPTION
wowchat was 1 spacebar away from this immediately working lmao

![image](https://github.com/fjaros/wowchat/assets/11151284/0f239f46-e291-41a1-8d29-f0272564a2a9)

the item link is working on my fork for turtle wow, heres the commit so the wider community can enjoy

i dont have the means to test the achivement links tho. but I assumed the same spacebar remove will do the trick